### PR TITLE
Fixing multiple open windows potentially breaking the extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -47,7 +47,7 @@ function download(downloadAs) {
         currentWindow: true
     };
 
-    return chrome.tabs.query({active:true}, function (tab) {
+    return chrome.tabs.query(query, function (tab) {
         tab = tab[0];
         result = chromeURLPattern.exec(tab.url);
         if (result && result[1]) {

--- a/popup.js
+++ b/popup.js
@@ -58,7 +58,7 @@ function ready() {
     document.getElementById('rating').onclick = function () {
         window.open("https://chrome.google.com/webstore/detail/crx-extractordownloader/ajkhmmldknmfjnmeedkbkkojgobmljda/reviews");
     };
-    chrome.tabs.query({active:true}, function (tab) {
+    chrome.tabs.query({active:true, currentWindow: true}, function (tab) {
         tab = tab[0];
         var id = chromeURLPattern.exec(tab.url);
 


### PR DESCRIPTION
Fixing failure to get current tab URL when there are multiple open windows and a different active tab is returned.